### PR TITLE
Fix xtend compilation issue 1373

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,31 @@
 						</configuration>
 					</execution>
 				</executions>
+				<!-- workaround https://github.com/eclipse/xtext/issues/1231 -->
+				<!-- workaround https://github.com/eclipse/xtext/issues/1373 -->
+				<!-- Remove with upgrade to Xtext 2.15 -->
+				<dependencies>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.core</artifactId>
+						<version>3.13.102</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+						<version>1.3.110</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.jdt</groupId>
+						<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+						<version>1.2.101</version>
+					</dependency>
+					<dependency>
+						<groupId>org.eclipse.emf</groupId>
+						<artifactId>org.eclipse.emf.codegen</artifactId>
+						<version>2.11.0</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 			<!-- enable generation of Eclipse-SourceReferences MANIFEST header -->
 			<plugin>


### PR DESCRIPTION
Applies the workaround suggested by
https://github.com/eclipse/xtext/issues/1373

fixes bug https://github.com/eclipse/gemoc-studio/issues/131

This workaround should be removed when bumping to xtext/xtend 2.15+

Comes with https://github.com/eclipse/gemoc-studio-modeldebugging/pull/79 and https://github.com/eclipse/gemoc-studio/pull/132