### PR TITLE
Bump ALE version to 2019-06-24

### DIFF
--- a/docs/dev/ALEExecution.asciidoc
+++ b/docs/dev/ALEExecution.asciidoc
@@ -9,7 +9,7 @@ ifndef::includedInMaster[]
 
 endif::[]
 
-[[execution-engines-java-execution]]
+[[execution-engines-ale-execution]]
 ==== ALE Execution 
 
 footnote:[asciidoc source of this page:  https://github.com/eclipse/gemoc-studio-execution-ale/tree/master/docs/dev/ALEExecution.asciidoc.]

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-02-06</ale-repo.url>
+		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-06-24</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06</melange-repo.url>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
contains several bug fixes
comes with https://github.com/eclipse/gemoc-studio/pull/166

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>