### PR TITLE
Clarifies Eclipse consoles used by the engines

### DIFF
--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/Activator.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/Activator.java
@@ -62,7 +62,7 @@ public class Activator extends AbstractUIPlugin {
 		if (messaggingSystem == null) {
 			MessagingSystemManager msm = new MessagingSystemManager();
 			messaggingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID,
-					"Modeling workbench console");
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messaggingSystem;
 	}

--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/Activator.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/Activator.java
@@ -61,7 +61,8 @@ public class Activator extends AbstractUIPlugin {
 	public MessagingSystem getMessaggingSystem() {
 		if (messaggingSystem == null) {
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messaggingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID,
+			messaggingSystem = msm.createBestPlatformMessagingSystem(
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID,
 					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messaggingSystem;


### PR DESCRIPTION
This PR clarifies the use of various Eclipse consoles used by the engines.

It makes sure to use a unique console for most engines messages.
The name for this console is currently *Modeling Workbench Console*

This PR comes with several other PR: https://github.com/eclipse/gemoc-studio-modeldebugging/pull/116 https://github.com/eclipse/gemoc-studio-execution-moccml/pull/17