### PR TITLE
Stop engine on error

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gemoc-studio-execution-ale</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/META-INF/MANIFEST.MF
@@ -1,8 +1,8 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Gemoc ALE Engine UI
+Bundle-Name: GEMOC ALE Engine UI
 Bundle-SymbolicName: org.eclipse.gemoc.ale.interpreted.engine.ui;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Automatic-Module-Name: org.eclipse.gemoc.ale.interpreted.engine.ui
 Bundle-Activator: org.eclipse.gemoc.ale.interpreted.engine.ui.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
-Bundle-Name: Gemoc ALE Engine
+Bundle-Name: GEMOC ALE Engine
 Bundle-SymbolicName: org.eclipse.gemoc.ale.interpreted.engine;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.1.qualifier
 Export-Package: org.eclipse.gemoc.ale.interpreted.engine,
  org.eclipse.gemoc.ale.interpreted.engine.debug,
  org.eclipse.gemoc.ale.interpreted.engine.sirius

--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
@@ -155,11 +155,14 @@ public class AleEngine extends AbstractSequentialExecutionEngine<SequentialModel
 		
 		if(interpreter != null && parsedSemantics != null && init.isPresent()) {
 			IEvaluationResult res = interpreter.eval(caller, init.get(), args, parsedSemantics);
-			interpreter.getLogger().diagnosticForHuman();
 			
 			if(res.getDiagnostic().getMessage() != null) {
 				System.out.println(res.getDiagnostic().getMessage());
+				interpreter.getLogger().notify(res.getDiagnostic());
+				interpreter.getLogger().diagnosticForHuman();
 				throw new RuntimeException(res.getDiagnostic().getMessage());
+			} else {
+				interpreter.getLogger().diagnosticForHuman();
 			}
 		}
 	}

--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
@@ -129,6 +129,7 @@ public class AleEngine extends AbstractSequentialExecutionEngine<SequentialModel
 				
 				if(res.getDiagnostic().getMessage() != null) {
 					System.out.println(res.getDiagnostic().getMessage());
+					throw new RuntimeException(res.getDiagnostic().getMessage());
 				}
 			}
 			else {
@@ -137,6 +138,7 @@ public class AleEngine extends AbstractSequentialExecutionEngine<SequentialModel
 				
 				if(res.getDiagnostic().getMessage() != null) {
 					System.out.println(res.getDiagnostic().getMessage());
+					throw new RuntimeException(res.getDiagnostic().getMessage());
 				}
 			}
 			
@@ -157,6 +159,7 @@ public class AleEngine extends AbstractSequentialExecutionEngine<SequentialModel
 			
 			if(res.getDiagnostic().getMessage() != null) {
 				System.out.println(res.getDiagnostic().getMessage());
+				throw new RuntimeException(res.getDiagnostic().getMessage());
 			}
 		}
 	}

--- a/plugins/org.eclipse.gemoc.ale.language.sample.deployer/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.gemoc.ale.language.sample.deployer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Deployer
 Bundle-SymbolicName: org.eclipse.gemoc.ale.language.sample.deployer;singleton:=true
-Bundle-Version: 0.0.1.qualifier
+Bundle-Version: 1.0.1.qualifier
 Automatic-Module-Name: org.eclipse.gemoc.ale.language.sample.deployer
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.sequential.language.wb.sample.deployer,

--- a/plugins/org.eclipse.gemoc.ale.language.sample.deployer/pom.xml
+++ b/plugins/org.eclipse.gemoc.ale.language.sample.deployer/pom.xml
@@ -14,7 +14,7 @@
 		<relativePath>../</relativePath>
 		<groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
 		<artifactId>org.eclipse.gemoc.ale.interpreted.engine.plugins</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
+		<version>1.0.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.ale.language.sample.deployer</artifactId>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -7,7 +7,7 @@
    <parent>
        <groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
        <artifactId>root</artifactId>
-       <version>0.0.1-SNAPSHOT</version>
+       <version>1.0.1-SNAPSHOT</version>
    </parent>
 
 	<artifactId>org.eclipse.gemoc.ale.interpreted.engine.plugins</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
 	<artifactId>root</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-08-07</ale-repo.url>
+		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-08-08</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06</melange-repo.url>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-06-24</ale-repo.url>
+		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-08-07</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06</melange-repo.url>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/releng/org.eclipse.gemoc.ale.interpreted.engine.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.ale.interpreted.engine.feature/feature.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.gemoc.ale.interpreted.engine.feature"
-      label="ALE Gemoc Engine"
-      version="0.0.1.qualifier"
+      label="GEMOC ALE Engine"
+      version="1.0.1.qualifier"
       provider-name="Inria/Obeo">
 
    <plugin
@@ -19,11 +19,11 @@
          version="0.0.0"
          unpack="false"/>
 
-    <plugin
-      id="org.eclipse.gemoc.ale.language.sample.deployer"
-      download-size="0"
-      install-size="0"
-      version="0.0.0"
-      unpack="false"/>
+   <plugin
+         id="org.eclipse.gemoc.ale.language.sample.deployer"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
 </feature>

--- a/releng/org.eclipse.gemoc.ale.interpreted.engine.feature/pom.xml
+++ b/releng/org.eclipse.gemoc.ale.interpreted.engine.feature/pom.xml
@@ -7,7 +7,7 @@
    <parent>
        <groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
        <artifactId>org.eclipse.gemoc.ale.interpreted.engine.releng</artifactId>
-       <version>0.0.1-SNAPSHOT</version>
+       <version>1.0.1-SNAPSHOT</version>
    </parent>
 
 	<artifactId>org.eclipse.gemoc.ale.interpreted.engine.feature</artifactId>

--- a/releng/org.eclipse.gemoc.ale.interpreted.engine.updatesite/category.xml
+++ b/releng/org.eclipse.gemoc.ale.interpreted.engine.updatesite/category.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_0.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="0.0.1.qualifier">
-      <category name="ALE Gemoc Engine"/>
+   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature_1.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature" version="1.0.1.qualifier">
+      <category name="ALE GEMOC Engine"/>
    </feature>
-   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature.source_0.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature.source" version="0.0.1.qualifier">
-      <category name="ALE Gemoc Engine"/>
+   <feature url="features/org.eclipse.gemoc.ale.interpreted.engine.feature.source_1.0.1.qualifier.jar" id="org.eclipse.gemoc.ale.interpreted.engine.feature.source" version="1.0.1.qualifier">
+      <category name="ALE GEMOC Engine"/>
    </feature>
-   <category-def name="ALE Gemoc Engine" label="ALE Gemoc Engine"/>
+   <category-def name="ALE GEMOC Engine" label="ALE GEMOC Engine"/>
 </site>

--- a/releng/org.eclipse.gemoc.ale.interpreted.engine.updatesite/pom.xml
+++ b/releng/org.eclipse.gemoc.ale.interpreted.engine.updatesite/pom.xml
@@ -7,7 +7,7 @@
    <parent>
        <groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
        <artifactId>org.eclipse.gemoc.ale.interpreted.engine.releng</artifactId>
-       <version>0.0.1-SNAPSHOT</version>
+       <version>1.0.1-SNAPSHOT</version>
    </parent>
 
 	<artifactId>org.eclipse.gemoc.ale.interpreted.engine.updatesite</artifactId>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -7,7 +7,7 @@
    <parent>
        <groupId>org.eclipse.gemoc.ale.interpreted.engine</groupId>
        <artifactId>root</artifactId>
-       <version>0.0.1-SNAPSHOT</version>
+       <version>1.0.1-SNAPSHOT</version>
    </parent>
 
 	<artifactId>org.eclipse.gemoc.ale.interpreted.engine.releng</artifactId>


### PR DESCRIPTION
This PR integrates the fix of https://github.com/gemoc/ale-lang/issues/38 . Ie. ALE Engine was not stopping the engine in case of unexpected execution error.

It bumps ALE version to the latest available and includes some additions in ALE GEMOC Engine.

This PR comes with the following PR:  https://github.com/eclipse/gemoc-studio/pull/176