### PR TITLE
Use AleInterpreter close

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-11-12</ale-repo.url>
+		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-11-13</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06</melange-repo.url>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-08-08</ale-repo.url>
+		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2019-11-12</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2018-09-06</melange-repo.url>
 		<maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
This PR bumps to the latest version of ALE which now offer a `close()` method in its interpreter.

Calling this method ensures dispose of unused resources that are retained by Sirius JavaExtension (via registration in the eclipse WorkkspaceListener)