### PR TITLE
Tycho 1.5 and p2 dependencies optimisation

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.2.0</version>
+    <version>1.5.1</version>
   </extension>
 </extensions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 
 	<properties>
-		<tycho.version>1.2.0</tycho.version>
+		<tycho.version>1.5.1</tycho.version>
 		<xtend.version>2.14.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>

--- a/pom.xml
+++ b/pom.xml
@@ -45,11 +45,7 @@
             <layout>p2</layout>
             <url>${melange-repo.url}</url>
         </repository>
-        <repository> <!-- this repo is used to provide jdom and jaxen plugins -->
-            <id>app4mc</id>
-            <layout>p2</layout>
-            <url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1/</url>
-        </repository>
+
 		<!-- not required because the build is supposed to be launched from gemoc-studio/dev_support/full_compilation/pom.xml
 		may be put in a maven profile if require ?
 		<repository>


### PR DESCRIPTION
Companion PR of https://github.com/eclipse/gemoc-studio/pull/189

This PR tries to optimize the build time on the CI with the following changes:

- update tycho from 1.2.0 to 1.5.1
- remove p2 repository APP4MC 