### PR TITLE
Added a console debug message indicating the implicit addons on start

### DIFF
--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/launcher/Launcher.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine.ui/src/org/eclipse/gemoc/ale/interpreted/engine/ui/launcher/Launcher.java
@@ -138,6 +138,7 @@ public class Launcher extends AbstractSequentialGemocLauncher<GenericModelExecut
 			Activator.error(e.getMessage(), e);
 		}
 
+		Activator.getDefault().getMessaggingSystem().debug("Enabled implicit addon: "+debugger.getAddonID(), getPluginID());
 		engine.getExecutionContext().getExecutionPlatform().addEngineAddon(debugger);
 		return debugger;
 	}


### PR DESCRIPTION
This is a companion PR to https://github.com/eclipse/gemoc-studio-modeldebugging/pull/149

This PR add some debug log on the console indicating the addons implicitly enabled by ALE engine.