### PR TITLE
Metaprogramming approach name changed to FullyQualifiedName

### DIFF
--- a/plugins/org.eclipse.gemoc.ale.language.metaprogramming/plugin.xml
+++ b/plugins/org.eclipse.gemoc.ale.language.metaprogramming/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
-            name="org.eclipse.gemoc.ale"
+            name="org.eclipse.gemoc.metaprog.ale"
             validator="org.eclipse.gemoc.ale.language.metaprogramming.AleRuleProvider">
       </approach>
    </extension>

--- a/plugins/org.eclipse.gemoc.ale.language.metaprogramming/plugin.xml
+++ b/plugins/org.eclipse.gemoc.ale.language.metaprogramming/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
-            name="ale"
+            name="org.eclipse.gemoc.ale"
             validator="org.eclipse.gemoc.ale.language.metaprogramming.AleRuleProvider">
       </approach>
    </extension>


### PR DESCRIPTION
Name changed from "ale" to "org.eclipse.gemoc.metaprog.ale".

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>