### PR TITLE
Bump eclipse 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.7.0</version>
+    <version>2.2.0</version>
   </extension>
 </extensions>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 
 	<properties>
-		<tycho.version>1.7.0</tycho.version>
+		<tycho.version>2.2.0</tycho.version>
 		<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/2020-12</eclipse-repo.url>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
 
 	<properties>
 		<tycho.version>1.7.0</tycho.version>
-		<xtend.version>2.21.0</xtend.version>
+		<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<eclipse-repo.url>http://download.eclipse.org/releases/2020-03</eclipse-repo.url>
+		<eclipse-repo.url>http://download.eclipse.org/releases/2020-12</eclipse-repo.url>
 		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange-repo.url>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<eclipse-repo.url>http://download.eclipse.org/releases/2020-12</eclipse-repo.url>
 		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2020-07-17</ale-repo.url>
 		<k3-repo.url>http://www.kermeta.org/k3/update_2018-09-05</k3-repo.url>
-		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange-repo.url>
+		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange-repo.url>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-ale.git</tycho.scmUrl>


### PR DESCRIPTION
## Description

This bump the base Eclipse to Eclipse 2020-12

This allows to solve start issue on MacOS

## Changes

It also bump other components:

- Xtend/Xtext to 2.24.0
- Tycho to 2.2.0
 
## Contribution to issues

Contribute to #  
Closes # 

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio/pull/219
 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/183
 - PR https://github.com/eclipse/gemoc-studio-execution-java/pull/14
 - PR https://github.com/eclipse/gemoc-studio-moccml/pull/17
 - PR https://github.com/eclipse/gemoc-studio-execution-moccml/pull/49
