### PR TITLE
Bump to Eclipse 2021-06

### DIFF
--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -10,42 +10,41 @@
 	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
-
+	<parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
+		<artifactId>gemoc_studio-eclipse-bom</artifactId>
+		<version>3.3.0-SNAPSHOT</version>
+		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
+	</parent>
+	
 	<properties>
-		<tycho.version>2.2.0</tycho.version>
-		<xtend.version>2.24.0</xtend.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<eclipse-repo.url>http://download.eclipse.org/releases/2020-12</eclipse-repo.url>
-		<ale-repo.url>http://www.kermeta.org/ale-lang/updates/2020-11-09</ale-repo.url>
-		<k3-repo.url>http://www.kermeta.org/k3/update</k3-repo.url>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange-repo.url>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-ale.git</tycho.scmUrl>
 		
-		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
 
 	<repositories>
 		<repository>
 			<id>Eclipse release</id>
-			<url>${eclipse-repo.url}</url>
+			<url>${eclipse.release.p2.url}</url>
 			<layout>p2</layout>
 		</repository>
 		<repository>
 			<id>ale</id>
-			<url>${ale-repo.url}</url>
+			<url>${ale.p2.url}</url>
 			<layout>p2</layout>
 		</repository>
 		<repository>
             <id>K3</id>
             <layout>p2</layout>
-            <url>${k3-repo.url}</url>
+            <url>${k3.p2.url}</url>
         </repository>
         <repository>
             <id>Melange</id>
             <layout>p2</layout>
-            <url>${melange-repo.url}</url>
+            <url>${melange.p2.url}</url>
         </repository>
 
 		<!-- not required because the build is supposed to be launched from gemoc-studio/dev_support/full_compilation/pom.xml
@@ -87,12 +86,12 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-packaging-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<dependencies>
 					<dependency>
 						<groupId>org.eclipse.tycho.extras</groupId>
 						<artifactId>tycho-sourceref-jgit</artifactId>
-						<version>${tycho.version}</version>
+						<version>${tycho-version}</version>
 					</dependency>
 				</dependencies>
 				<configuration>
@@ -105,7 +104,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<executions>
 					<execution>
 						<id>plugin-source</id>
@@ -119,7 +118,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<executions>
 					<execution>
 						<id>source-feature</id>
@@ -135,7 +134,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<executions>
 					<execution>
 						<id>attached-p2-metadata</id>
@@ -150,7 +149,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-surefire-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<configuration>
 					<useUIHarness>true</useUIHarness>
 					<useUIThread>false</useUIThread>
@@ -162,7 +161,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<configuration>
 					<dependency-resolution>
 						<extraRequirements>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -27,7 +27,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-maven-plugin</artifactId>
-				<version>${tycho.version}</version>
+				<version>${tycho-version}</version>
 				<extensions>true</extensions>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Bump Eclipse base to Eclipse 2021-06

Add a new root pom.xml acting as a BOM (Bill of Material) in order to centralize all update sites used by the gemoc studio repositories (this will help to bump most versions in a single file)

## Changes

 - increase  base version of the tools to the ones distributed with Eclipse 2021-06
 - add a new gemoc_studio-eclipse-bom project to centralize all update sites as properties in a single file
 - update splash screen using Eclipse IDE 2021-06 background
 
## Contribution to issues

Contribute to https://github.com/gemoc/gemoc-discussions/issues/6

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->


- https://github.com/eclipse/gemoc-studio/pull/231
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/196
- https://github.com/eclipse/gemoc-studio-execution-java/pull/19
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/49
- https://github.com/eclipse/gemoc-studio-moccml/pull/19
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/54