### PR TITLE
Bump to 3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	

--- a/releng/org.eclipse.gemoc.execution.ale.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.ale.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.execution.ale.feature"
       label="GEMOC ExecutionALE"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 


### PR DESCRIPTION
## Description

Bump GEMOC Studio version to 3.5.0

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/254
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/212
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/64
 - https://github.com/eclipse/gemoc-studio-moccml/pull/22
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/22