### PR TITLE
Bump eclipse 2021 12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.2.0</version>
+    <version>2.6.0</version>
   </extension>
 </extensions>
 

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.6.0</version>
+    <version>2.5.0</version>
   </extension>
 </extensions>
 


### PR DESCRIPTION
## Description
Bump Eclipse base IDE to 2021-12
use corresponding tycho (2.5.0) and xtend/xtext (2.25.0)

## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio/pull/255
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/213
- https://github.com/eclipse/gemoc-studio-execution-java/pull/23
- https://github.com/eclipse/gemoc-studio-moccml/pull/23
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/65