### PR TITLE
Use tpd for defining target platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,16 +26,7 @@
 	</properties>
 
 	<repositories>
-		<repository>
-			<id>Eclipse release</id>
-			<url>${eclipse.release.p2.url}</url>
-			<layout>p2</layout>
-		</repository>
-		<repository>
-			<id>ale</id>
-			<url>${ale.p2.url}</url>
-			<layout>p2</layout>
-		</repository>
+		
 		<repository>
             <id>K3</id>
             <layout>p2</layout>
@@ -163,7 +154,15 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<dependency-resolution>
+					<target>
+                        <artifact>
+                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+                            <version>3.5.0-SNAPSHOT</version>
+                            <classifier>gemoc_studio</classifier>
+                        </artifact>
+                    </target>
+					<!--<dependency-resolution>
 						<extraRequirements>
 
 							<requirement>
@@ -186,7 +185,7 @@
 
 						</extraRequirements>
 					</dependency-resolution>
-
+					-->
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
## Description
This PR changes the way the external update sites are imported in the build.
Instead of using maven repository like:
```
	<repositories>
		<repository>
			<id>Eclipse release</id>
			<layout>p2</layout>
			<url>${eclipse.release.p2.url}</url>
		</repository>
```
It uses a tpd description file in order to generate a targetplatform file.
This tpd allows to not specify precisely the version of the imported unit while helping to control where they come from.

A readme file explains how to update the target file from the tpd (in `gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform`)

NOTE: the use of the tpd is partial: the K3 and melange updatesite currently cannot be integrated in the target because these tools depends on gemoc.dsl that is actually build by GEMOC. This creates a kind of cycle in the targetplatfomr :disappointed: . Melange an K3 as thus still using the maven repository descriptor.

Additionally, the integration tests now explicitly use the gemoc product and target (this fix the javafx error preventing from opening the multidimentional view in the tests)

 :disappointed: I was expecting a speed up in the build (https://github.com/eclipse/gemoc-studio/issues/233) but, apparently, the newer version of tycho are optimized enough and there is no visible speed change.
 
## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/233


## Companion Pull Requests
 - https://github.com/eclipse/gemoc-studio/pull/259
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/216
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/66
 - https://github.com/eclipse/gemoc-studio-moccml/pull/24
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/53
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/24
