### PR TITLE
Bump to Eclipse 2022-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.3</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	
@@ -158,7 +158,7 @@
                         <artifact>
                             <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
                             <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
-                            <version>3.5.0-SNAPSHOT</version>
+                            <version>3.6.0-SNAPSHOT</version>
                             <classifier>gemoc_studio</classifier>
                         </artifact>
                     </target>

--- a/releng/org.eclipse.gemoc.execution.ale.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.ale.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.execution.ale.feature"
       label="GEMOC ExecutionALE"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 


### PR DESCRIPTION
## Description

Bump Eclipse base version to 2022-06 and its default version of its components
and update code to follow API changes.

Bump GEMOC studio version to 3.6.0

## Changes

- bump to tycho 2.7.3
- bump to newer version of Melange
- new splash screen
- adapt code to use xtext 2.27, remove some deprecated code, however the studio still include the `org.eclipse.xtext.generator` feature that is deprecated
- adapt code for use of Sirius 7.0.1
- some improvement in the system tests
 
## Contribution to issues

Contributes to https://github.com/eclipse/gemoc-studio/issues/270

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - PR https://github.com/eclipse/gemoc-studio/pull/273
 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/222
