### PR TITLE
Fix: remove self from step parameters

### DIFF
--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
@@ -83,7 +83,9 @@ public class AleEngine extends AbstractSequentialExecutionEngine<org.eclipse.gem
 								EObject currentCaller = (EObject) arguments[0];
 								String className = currentCaller.eClass().getName();
 								String methodName = service.getName();
-								beforeExecutionStep(currentCaller, className, methodName);
+								List<Object> parameters = Lists.newArrayList(Arrays.asList(arguments));
+								parameters.remove(0);
+								beforeExecutionStep(currentCaller, className, methodName, parameters);
 							}
 						}
 					}


### PR DESCRIPTION
## Description

ALE currently considers that the caller object is always part of the list of parameters of an execution step, while it should only be the caller object and not a parameter.

This PR fixes this problem by removing `self` from the list of parameters provided to the execution step.