### PR TITLE
Bump to version of k3 including StepCommand return null fix

### DIFF
--- a/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
+++ b/plugins/org.eclipse.gemoc.ale.interpreted.engine/src/org/eclipse/gemoc/ale/interpreted/engine/AleEngine.java
@@ -12,6 +12,7 @@ package org.eclipse.gemoc.ale.interpreted.engine;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -96,7 +97,7 @@ public class AleEngine extends AbstractSequentialExecutionEngine<org.eclipse.gem
 					if(service instanceof EvalBodyService) {
 						boolean isStep = ((EvalBodyService)service).getImplem().getTags().contains("step");
 						if(isStep) {
-							afterExecutionStep(Optional.of(result));
+							afterExecutionStep(Collections.singletonList(result));
 						}
 					}
 				}


### PR DESCRIPTION
## Description

Bump to the latest version of K3 that includes the support for all kind of StepCommand (ie. result being void, null or an object)

## Changes

Adapt the engine to the new return structure (ie.  List)

## Companion Pull Requests


 - https://github.com/eclipse/gemoc-studio/pull/284
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/229
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/30
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/74
