### PR TITLE
Bump to Eclipse 2023 06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.3</version>
+		<version>3.0.4</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 	
 	<properties>
 		<melange-repo.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange-repo.url>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-ale.git</tycho.scmUrl>
 		
 	</properties>
@@ -103,21 +103,18 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
-				</executions>
-			</plugin>
-			<!-- enable source feature generation -->
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
 					<execution>
-						<id>source-feature</id>
-						<phase>package</phase>
-						<goals>
-							<goal>source-feature</goal>
-						</goals>
-					</execution>
+			            <id>feature-source</id>
+			            <goals>
+			              <goal>feature-source</goal>
+			            </goals>
+			            <configuration>
+			              <excludes>
+			                <!-- provide plug-ins not containing any source code -->
+			                <!-- also possible to exclude feature-->
+			              </excludes>
+			            </configuration>
+          			</execution>
 				</executions>
 			</plugin>
 			<!-- required in order to embed feature and bundle sources in the update 


### PR DESCRIPTION
## Description

Upgrade the base Eclipse to Eclipse 2023-06.
Applies the changes required by the new version of components (XText, Xtend, Sirius)
New minimal requirement : java 17

## Changes

<!-- more details , changed documentation sections, changed version, some details about the code changes -->
 
 - Use java 17 in the CI docker image
 - new splash screen
 - use tycho 3.0.4
 - use xtend 2.31
 - use lsp4j 0.21
 - change maven plugin for generating plantuml images
 - fix melangeK3FSM project nature
 - remove use of deprecated xtext.MergeableManifest
 
## Contribution to issues

Contribute to #298 

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/299
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/232
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/61
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/32
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/77
 - https://github.com/eclipse/gemoc-studio-moccml/pull/28
 - https://github.com/eclipse/gemoc-studio-commons/pull/4
